### PR TITLE
Add hover styles to action items

### DIFF
--- a/src/popup.css
+++ b/src/popup.css
@@ -23,6 +23,10 @@ body {
 	margin-bottom: 4px;
 }
 
+#items > .item:hover {
+	text-decoration: underline;
+}
+
 #items > *[data-matched=false] {
 	display: none;
 }

--- a/src/popup.js
+++ b/src/popup.js
@@ -19,6 +19,7 @@ function initItems(items)
 	items.forEach((itm, idx) => {
 		let el = document.createElement('div')
 		el.setAttribute('tabindex', '2')
+		el.className = 'item'
 		el.textContent = itm.name
 		el.dataset.name = itm.name
 		el.addEventListener('keydown', ev => {


### PR DESCRIPTION
Small UX improvement, to better see which list item is currently under the cursor. Useful especially when moving mouse pointer on the blank space right to the item text.

Adding class to each item was necessary, because - for unknown reason - selector `#items > *:hover` didn't work in Firefox.